### PR TITLE
Use the public DNS if available

### DIFF
--- a/lib/elbas/capistrano.rb
+++ b/lib/elbas/capistrano.rb
@@ -18,7 +18,7 @@ def autoscale(groupname, *args)
       p "ELBAS: Skipping unhealthy instance #{instance.id}"
     else
       ec2_instance = ec2_resource.instance(asg_instance.id)
-      hostname = ec2_instance.private_ip_address
+      hostname = ec2_instance.public_dns_name || ec2_instance.private_ip_address
       p "ELBAS: Adding server: #{hostname}"
       server(hostname, *args)
     end


### PR DESCRIPTION
This brings it back in line with the original source before the multi ASG change.